### PR TITLE
setting generated zip file permissions to 644 by default instead of 600 ...

### DIFF
--- a/MVZipFiles.m
+++ b/MVZipFiles.m
@@ -58,6 +58,8 @@
 	// handle the task's termination status
 	if ([zipTask terminationStatus] == 0) {
 		[zipTask release];
+        NSDictionary *attributes=[NSDictionary dictionaryWithObject:[NSNumber numberWithShort:0644] forKey:NSFilePosixPermissions];
+        [[NSFileManager defaultManager] setAttributes:attributes ofItemAtPath:path error:nil];
 		return path;
 	}
 	[zipTask release];


### PR DESCRIPTION
...so that webservers can read the file

this is in reference to #11
